### PR TITLE
Fixed #35461 -- Added detail in django tutorial step 8 so that django-debug-toolbar works as expected.

### DIFF
--- a/docs/intro/tutorial08.txt
+++ b/docs/intro/tutorial08.txt
@@ -48,11 +48,15 @@ The steps are not duplicated in this tutorial, because as a third-party
 package, it may change separately to Django's schedule.
 
 Once installed, you should be able to see the DjDT "handle" on the right side
-of the browser window when you refresh the polls application. Click it to open
+of the browser window when you refresh the admin of your project. Click it to open
 the debug toolbar and use the tools in each panel. See the `panels
 documentation page
 <https://django-debug-toolbar.readthedocs.io/en/latest/panels.html>`__ for more
 information on what the panels show.
+
+To see the toolbar in the polls application in addition to the admin, make sure 
+all your templates are wrapped in complete HTML and their content is 
+inside the ``<body></body>`` tags.
 
 Getting help from others
 ========================


### PR DESCRIPTION
One solution for https://code.djangoproject.com/ticket/35461

# Trac ticket number
[ticket-35461](https://code.djangoproject.com/ticket/35461)

# Branch description
- Following the tutorial 'as is' won't lead to the toolbar working in /polls because the tutorial omits usage of complete HTML templates.
- This solution proposal implements an option of the list of options discussed in the thread. Reasoning available [here](https://www.notion.so/Tutorial-instructions-for-adding-django-debug-toolbar-are-misleading-1f1429081df4473cb5bad80790cc4176).

![image](https://github.com/RosanaRufer/django/assets/4906291/1a1fa561-628b-4ce5-860a-dff50f4d7797)


# Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- [x] I have attached screenshots in both light and dark modes for any UI changes.
